### PR TITLE
Standardize starting resources and add second player rug

### DIFF
--- a/marrakesh/client/lib/api.ts
+++ b/marrakesh/client/lib/api.ts
@@ -100,9 +100,9 @@ function ensureGameState(session: Session): GameState {
 }
 
 function defaultCoinsForCount(count: number) {
-  if (count === 2) return 60;
-  if (count === 3) return 40;
-  return 30;
+  if (count === 2) return 24;
+  if (count === 3) return 15;
+  return 12;
 }
 
 function defaultRugsForCount(count: number) {

--- a/marrakesh/client/lib/api.ts
+++ b/marrakesh/client/lib/api.ts
@@ -99,16 +99,12 @@ function ensureGameState(session: Session): GameState {
   all[session.id] = initial; setStates(all); return initial;
 }
 
-function defaultCoinsForCount(count: number) {
-  if (count === 2) return 24;
-  if (count === 3) return 15;
-  return 12;
+function defaultCoinsForCount(_count: number) {
+  return 30;
 }
 
-function defaultRugsForCount(count: number) {
-  if (count === 2) return 24;
-  if (count === 3) return 15;
-  return 12;
+function defaultRugsForCount(_count: number) {
+  return 24;
 }
 
 function nextPlayerId(session: Session, currentId?: string) { const order = session.turnOrder || []; if (order.length === 0) return undefined; const idx = currentId ? order.indexOf(currentId) : -1; const next = order[(idx + 1) % order.length]; return next; }

--- a/marrakesh/client/pages/Session.tsx
+++ b/marrakesh/client/pages/Session.tsx
@@ -8,6 +8,7 @@ import { GameState, Session } from "@shared/api";
 import { toast } from "sonner";
 
 const RUG_TEXTURE_URL = "https://cdn.builder.io/api/v1/image/assets%2F9c98f74ce2d9433495c720297d8c0a5c%2F22506cd4c0d54c62a09870a1145f0ae3?format=webp&width=800";
+const SECOND_PLAYER_RUG_TEXTURE_URL = "https://cdn.builder.io/api/v1/image/assets%2Ff96640d3454f4d9d93d1f5860e5ddd77%2Fb6d287fdf27f4c729d8d718de7640156?format=webp&width=800";
 const SECOND_PLAYER_RUG_COLOR = "#dc2626";
 const STARTING_COINS = 30;
 const STARTING_RUGS = 24;
@@ -149,10 +150,12 @@ export default function SessionPage() {
             : colorFor(ownerId)
           : undefined;
 
+        const textureUrl = ownerId === secondPlayerId ? SECOND_PLAYER_RUG_TEXTURE_URL : RUG_TEXTURE_URL;
+
         return {
           ownerId,
           color,
-          textureUrl: RUG_TEXTURE_URL,
+          textureUrl,
           orientation,
           segment,
         };

--- a/marrakesh/client/pages/Session.tsx
+++ b/marrakesh/client/pages/Session.tsx
@@ -9,12 +9,8 @@ import { toast } from "sonner";
 
 const RUG_TEXTURE_URL = "https://cdn.builder.io/api/v1/image/assets%2F9c98f74ce2d9433495c720297d8c0a5c%2F22506cd4c0d54c62a09870a1145f0ae3?format=webp&width=800";
 const SECOND_PLAYER_RUG_COLOR = "#dc2626";
-
-function startingPoolForPlayerCount(count: number) {
-  if (count === 2) return 24;
-  if (count === 3) return 15;
-  return 12;
-}
+const STARTING_COINS = 30;
+const STARTING_RUGS = 24;
 
 export default function SessionPage() {
   const { id = "" } = useParams();
@@ -55,7 +51,6 @@ export default function SessionPage() {
   }, [id, token]);
 
   const players = session?.players ?? [];
-  const startingPool = startingPoolForPlayerCount(players.length);
   const secondPlayerId = players[1]?.id ?? null;
   const activePlayerId = state?.activePlayerId;
   const isMyTurn = Boolean(user && activePlayerId === user.id);
@@ -275,8 +270,8 @@ export default function SessionPage() {
                   </div>
                 </div>
                 <div className="flex items-center gap-3 text-muted-foreground">
-                  <span title="Монеты" className="min-w-10 text-right">💰 {state?.balances?.[p.id] ?? startingPool}</span>
-                  <span title="Ковры" className="min-w-8 text-right">🧶 {state?.rugsLeft?.[p.id] ?? startingPool}</span>
+                  <span title="Монеты" className="min-w-10 text-right">💰 {state?.balances?.[p.id] ?? STARTING_COINS}</span>
+                  <span title="Ковры" className="min-w-8 text-right">🧶 {state?.rugsLeft?.[p.id] ?? STARTING_RUGS}</span>
                 </div>
               </li>
             ))}

--- a/marrakesh/client/pages/Session.tsx
+++ b/marrakesh/client/pages/Session.tsx
@@ -8,6 +8,7 @@ import { GameState, Session } from "@shared/api";
 import { toast } from "sonner";
 
 const RUG_TEXTURE_URL = "https://cdn.builder.io/api/v1/image/assets%2F9c98f74ce2d9433495c720297d8c0a5c%2F22506cd4c0d54c62a09870a1145f0ae3?format=webp&width=800";
+const SECOND_PLAYER_RUG_COLOR = "#dc2626";
 
 export default function SessionPage() {
   const { id = "" } = useParams();
@@ -48,6 +49,7 @@ export default function SessionPage() {
   }, [id, token]);
 
   const players = session?.players ?? [];
+  const secondPlayerId = players[1]?.id ?? null;
   const activePlayerId = state?.activePlayerId;
   const isMyTurn = Boolean(user && activePlayerId === user.id);
   const gameFinished = state?.status === "finished";
@@ -97,7 +99,7 @@ export default function SessionPage() {
   const playerColors = useMemo(() => {
     const colorMap: Record<string, string> = {};
     players.forEach((player, index) => {
-      colorMap[player.id] = index === 1 ? "#dc2626" : baseColorFor(player.id);
+      colorMap[player.id] = index === 1 ? SECOND_PLAYER_RUG_COLOR : baseColorFor(player.id);
     });
     return colorMap;
   }, [players]);
@@ -139,16 +141,22 @@ export default function SessionPage() {
           segment = "end";
         }
 
+        const color = ownerId
+          ? ownerId === secondPlayerId
+            ? SECOND_PLAYER_RUG_COLOR
+            : colorFor(ownerId)
+          : undefined;
+
         return {
           ownerId,
-          color: ownerId ? colorFor(ownerId) : undefined,
+          color,
           textureUrl: RUG_TEXTURE_URL,
           orientation,
           segment,
         };
       }),
     );
-  }, [playerColors, state, size]);
+  }, [playerColors, secondPlayerId, state, size]);
 
   async function onRotate(turn: "left" | "right") {
     if (gameFinished) return;

--- a/marrakesh/client/pages/Session.tsx
+++ b/marrakesh/client/pages/Session.tsx
@@ -10,6 +10,12 @@ import { toast } from "sonner";
 const RUG_TEXTURE_URL = "https://cdn.builder.io/api/v1/image/assets%2F9c98f74ce2d9433495c720297d8c0a5c%2F22506cd4c0d54c62a09870a1145f0ae3?format=webp&width=800";
 const SECOND_PLAYER_RUG_COLOR = "#dc2626";
 
+function startingPoolForPlayerCount(count: number) {
+  if (count === 2) return 24;
+  if (count === 3) return 15;
+  return 12;
+}
+
 export default function SessionPage() {
   const { id = "" } = useParams();
   const { token, user } = useAuth();
@@ -49,6 +55,7 @@ export default function SessionPage() {
   }, [id, token]);
 
   const players = session?.players ?? [];
+  const startingPool = startingPoolForPlayerCount(players.length);
   const secondPlayerId = players[1]?.id ?? null;
   const activePlayerId = state?.activePlayerId;
   const isMyTurn = Boolean(user && activePlayerId === user.id);
@@ -268,8 +275,8 @@ export default function SessionPage() {
                   </div>
                 </div>
                 <div className="flex items-center gap-3 text-muted-foreground">
-                  <span title="Монеты" className="min-w-10 text-right">💰 {state?.balances?.[p.id] ?? 30}</span>
-                  <span title="Ковры" className="min-w-8 text-right">🧶 {state?.rugsLeft?.[p.id] ?? 12}</span>
+                  <span title="Монеты" className="min-w-10 text-right">💰 {state?.balances?.[p.id] ?? startingPool}</span>
+                  <span title="Ковры" className="min-w-8 text-right">🧶 {state?.rugsLeft?.[p.id] ?? startingPool}</span>
                 </div>
               </li>
             ))}


### PR DESCRIPTION
## Purpose

Based on user feedback, this change standardizes the starting game resources to ensure fair gameplay. Users requested that all players start with equal amounts of money and rugs (30 coins and 24 rugs each), and wanted a unique rug texture for the second player to improve visual distinction.

## Code changes

- **Resource balancing**: Modified `defaultCoinsForCount()` and `defaultRugsForCount()` functions to return fixed values (30 coins, 24 rugs) regardless of player count
- **Visual improvements**: Added constants for second player's rug texture URL and color
- **Second player customization**: Implemented logic to apply different rug texture and color specifically for the second player
- **UI consistency**: Updated player display to use the new starting resource constants

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fcdc378a3106481fa14a012c83cc596a/vortex-world)

👀 [Preview Link](https://fcdc378a3106481fa14a012c83cc596a-vortex-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fcdc378a3106481fa14a012c83cc596a</projectId>-->
<!--<branchName>vortex-world</branchName>-->